### PR TITLE
Replace deprecated HF_HUB_ENABLE_HF_TRANSFER env var

### DIFF
--- a/comfy/cmd/main_pre.py
+++ b/comfy/cmd/main_pre.py
@@ -10,7 +10,7 @@ It will enable command line argument parsing. If this isn't desired, you must au
 import os
 
 os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
-os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
 os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "1"
 os.environ["TORCHINDUCTOR_AUTOGRAD_CACHE"] = "1"
 os.environ["BITSANDBYTES_NOWELCOME"] = "1"

--- a/comfy/model_downloader.py
+++ b/comfy/model_downloader.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import List, Optional, Final, Set
 
 # enable better transfer
-os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
 
 import tqdm
 from huggingface_hub import hf_hub_download, scan_cache_dir, snapshot_download, HfFileSystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "pyjwt[crypto]",
     "kornia>=0.7.0",
     "mpmath>=1.0,!=1.4.0a0",
-    "huggingface_hub[hf_transfer]",
+    "huggingface_hub",
     "lazy-object-proxy",
     "lazy_loader>=0.3",
     "can_ada",


### PR DESCRIPTION
This is a companion update to https://github.com/livepeer/ai-runner/pull/837